### PR TITLE
UART support

### DIFF
--- a/boards/nano9k/constraints.cst
+++ b/boards/nano9k/constraints.cst
@@ -1,3 +1,6 @@
+IO_LOC  "uart_rx" 18;
+IO_PORT "uart_rx" IO_TYPE=LVCMOS33;
+
 IO_LOC  "clk" 52;
 IO_PORT "clk" IO_TYPE=LVCMOS33 PULL_MODE=UP;
 

--- a/boards/nano9k/top.v
+++ b/boards/nano9k/top.v
@@ -8,7 +8,11 @@ module nano9k (
     input uart_rx,
     output reg [5:0] led
 );
-    cpu cpu(clk, btn1);
-    uart uart(clk, uart_rx, led);
+    wire cpu_enable;
     
+    cpu Cpu(clk, btn1, cpu_enable);
+    uart Uart(clk, uart_rx, led, cpu_enable);
+    
+    assign Cpu.Rom.memory = Uart.memory;
+
 endmodule

--- a/boards/nano9k/top.v
+++ b/boards/nano9k/top.v
@@ -1,10 +1,14 @@
 // Top Level Target for Nano 9k
 `include "../../project/cpu.v"
+`include "../../project/uart.v"
 
 module nano9k (
     input clk,
     input btn1,
+    input uart_rx,
+    output reg [5:0] led
 );
     cpu cpu(clk, btn1);
+    uart uart(clk, uart_rx, led);
     
 endmodule

--- a/project/cpu.v
+++ b/project/cpu.v
@@ -11,7 +11,9 @@
 module cpu(
     input clock,
     input reset,
+    input enable,
 );
+    assign clock_real = clock & enable;
     // ### Component wires ###
 
     // ROM
@@ -29,7 +31,7 @@ module cpu(
     // ### Components ###
 
     ram ram(
-        .clk(clock), 
+        .clk(clock_real), 
         .reset(reset),
         .address(ram_address),
         .data_in(ram_data_in),
@@ -37,13 +39,13 @@ module cpu(
         .data_out(ram_data_out),
     );
 
-    rom rom(
+    rom Rom(
         .address(rom_address),
         .data(rom_data),
     );
 
     register_bank RegisterBank(
-        .clk(clock),
+        .clk(clock_real),
         .reset(reset),
         .write_enable(rb_write_enable),
         .write_address(rb_write_address),
@@ -102,7 +104,7 @@ module cpu(
     // ### Pipeline ###
 
     fetch fetch(
-        .clk(clock),
+        .clk(clock_real),
         .rst(reset),
         
         .branch_target(wr_if_branch_target), // May come from writeback, but ideally from memory stage
@@ -115,7 +117,7 @@ module cpu(
     );
 
     decode decode(
-        .clk(clock),
+        .clk(clock_real),
         .rst(reset),
         
         .next_instruction(if_de_instr),
@@ -130,7 +132,7 @@ module cpu(
     );
 
     execute execute(
-        .clk(clock),
+        .clk(clock_real),
         .rst(reset),
         
         .rs1_value(rb_value1),
@@ -154,7 +156,7 @@ module cpu(
     );
 
     memory memory(
-        .clk(clock),
+        .clk(clock_real),
         .rst(reset),
 
         .addr(),
@@ -180,7 +182,7 @@ module cpu(
     );
 
     writeback writeback(
-        .clk(clock),
+        .clk(clock_real),
         .rst(reset),
 
         .mem_done(mem_wr_mem_done),

--- a/project/uart.v
+++ b/project/uart.v
@@ -1,0 +1,79 @@
+// MODIFIED FROM https://learn.lushaylabs.com/tang-nano-9k-debugging
+//`default_nettype none
+
+module uart
+#(
+    parameter DELAY_FRAMES = 234  // Delay frames expecting a 115200 Baud rate
+)
+(
+    input clk,
+    input uart_rx,
+    output reg [5:0] led
+);
+
+localparam HALF_DELAY_WAIT = (DELAY_FRAMES / 2);
+
+reg [7:0] dataIn = 0;
+reg [2:0] rxState = 0;
+reg [12:0] rxCounter = 0;
+reg [2:0] rxBitNumber = 0;
+reg byteReady = 0;
+
+localparam RX_STATE_IDLE = 0;
+localparam RX_STATE_START_BIT = 1;
+localparam RX_STATE_READ_WAIT = 2;
+localparam RX_STATE_READ = 3;
+localparam RX_STATE_STOP_BIT = 4;
+
+always @(posedge clk) begin
+    case (rxState)
+        RX_STATE_IDLE: begin
+            if (uart_rx == 0) begin
+                rxState <= RX_STATE_START_BIT;
+                rxCounter <= 1;
+                rxBitNumber <= 0;
+                byteReady <= 0;
+            end
+        end 
+        RX_STATE_START_BIT: begin
+            if (rxCounter == HALF_DELAY_WAIT) begin
+                rxState <= RX_STATE_READ_WAIT;
+                rxCounter <= 1;
+            end else 
+                rxCounter <= rxCounter + 1;
+        end
+        RX_STATE_READ_WAIT: begin
+            rxCounter <= rxCounter + 1;
+            if ((rxCounter + 1) == DELAY_FRAMES) begin
+                rxState <= RX_STATE_READ;
+            end
+        end
+        RX_STATE_READ: begin
+            rxCounter <= 1;
+            dataIn <= {uart_rx, dataIn[7:1]};
+            rxBitNumber <= rxBitNumber + 1;
+            if (rxBitNumber == 3'b111)
+                rxState <= RX_STATE_STOP_BIT;
+            else
+                rxState <= RX_STATE_READ_WAIT;
+        end
+        RX_STATE_STOP_BIT: begin
+            rxCounter <= rxCounter + 1;
+            if ((rxCounter + 1) == DELAY_FRAMES) begin
+                rxState <= RX_STATE_IDLE;
+                rxCounter <= 0;
+                byteReady <= 1;
+            end
+        end
+    endcase
+end
+
+always @(posedge clk) begin
+    if (byteReady) begin
+        // Should be changed to use byte transmitted for something
+        // Currently changes LEDs for testing purposes
+        led <= ~dataIn[5:0];
+    end
+end
+
+endmodule

--- a/send_serial.py
+++ b/send_serial.py
@@ -1,21 +1,22 @@
 import serial  # pip install pyserial
 
-port = "COM4"  # Insert port connected to board here
+port = ""  # Insert port connected to board here
 
 serialPort = serial.Serial(port=port, baudrate=115200, bytesize=8, timeout=2, stopbits=serial.STOPBITS_ONE)
 
-f = open("./tests/binaries/TestsArith.hex", "rt")
+f = open("./tests/binaries/", "rt")  # Insert .hex file to be sent
 code = f.read()
 
-ascii_string = ''
+bindata = []
 x = 0
 y = 2
 l = len(code)
 while y <= l:
-    if code[x] != '\r' and '\n':
-        ascii_string += chr(int(code[x:y], 16))
-    x += 2
-    y += 2
-print(ascii_string)
-print(str.encode(ascii_string))
-serialPort.write(str.encode(ascii_string))
+    if code[x] != '\r' and code[x] != '\n':
+        bindata.append(int(code[x:y], 16))
+        x += 2
+        y += 2
+    else:
+        x += 1
+        y += 1
+serialPort.write(bindata)

--- a/send_serial.py
+++ b/send_serial.py
@@ -1,10 +1,10 @@
 import serial  # pip install pyserial
 
-port = ""  # Insert port connected to board here
+port = "COM6"  # Insert port connected to board here
 
 serialPort = serial.Serial(port=port, baudrate=115200, bytesize=8, timeout=2, stopbits=serial.STOPBITS_ONE)
 
-f = open("./tests/binaries/", "rt")  # Insert .hex file to be sent
+f = open("./tests/binaries/test.bin", "rt")  # Insert .hex file to be sent
 code = f.read()
 
 bindata = []

--- a/send_serial.py
+++ b/send_serial.py
@@ -1,0 +1,21 @@
+import serial  # pip install pyserial
+
+port = "COM4"  # Insert port connected to board here
+
+serialPort = serial.Serial(port=port, baudrate=115200, bytesize=8, timeout=2, stopbits=serial.STOPBITS_ONE)
+
+f = open("./tests/binaries/TestsArith.hex", "rt")
+code = f.read()
+
+ascii_string = ''
+x = 0
+y = 2
+l = len(code)
+while y <= l:
+    if code[x] != '\r' and '\n':
+        ascii_string += chr(int(code[x:y], 16))
+    x += 2
+    y += 2
+print(ascii_string)
+print(str.encode(ascii_string))
+serialPort.write(str.encode(ascii_string))


### PR DESCRIPTION
Added UART support to send RISC-V assembly hex files to the tang nano 9k board, contained in two parts, a UART verilog module and a python script for communication

- Verilog Module
The UART verilog module works at a 115200 Baud rate, it is constructed to read the information being sent at the half point of the signal, to avoid reading issues. Currently its only used to light up the board LEDs as a proof of concept, but it should be easily modifiable to add the received bytes to memory to be used by the board CPU. (Based on: [learn.lushaylabs.com/tang-nano-9k-debugging/#transmitting-data](https://learn.lushaylabs.com/tang-nano-9k-debugging/#transmitting-data))

- Python Script
The python script opens a serial port that should be configured to the port the board is connected to your device and sends the information of the file specified in its code to the board, sending each byte separately.