### PR TITLE
Reduce total UART instructions and fix address reg size

### DIFF
--- a/boards/nano9k/top.v
+++ b/boards/nano9k/top.v
@@ -16,7 +16,8 @@ module nano9k (
     output [5:0] led
 );
     wire cpu_enable;
-    wire [31:0] instruction_data, instruction_address;
+    wire [31:0] instruction_data;
+    wire [7:0] instruction_address;
     
     localparam WAIT_TIME = 5000000;
     wire effClk;

--- a/project/cpu.v
+++ b/project/cpu.v
@@ -21,7 +21,7 @@ module cpu(
     output [5:0] led,
     input enable,
     input wire [31:0] rom_data,
-    output wire [31:0] rom_address
+    output wire [7:0] rom_address
 );
     // assign led[5:0] = ex_mem_result[5:0];
 

--- a/project/cpu/fetch.v
+++ b/project/cpu/fetch.v
@@ -9,7 +9,7 @@ module fetch (
 
     input PCSrc,
 
-    output [31:0] rom_address,
+    output [7:0] rom_address,
 
     output reg [31:0] pc = 32'b0, // Register for the address of the next instruction (10-bit address for 1024 registers)
     output wire [31:0] instr      // Instruction fetched from memory
@@ -24,7 +24,7 @@ module fetch (
     end
 
     assign instr = rom_data;
-    assign rom_address = pc;
+    assign rom_address = pc[7:0];
 
 endmodule
 `endif

--- a/project/uart.v
+++ b/project/uart.v
@@ -7,7 +7,7 @@ module uart
     input uart_rx,
     //output reg [5:0] led,
     output reg cpu_enable = 0,
-    input wire [31:0] address,
+    input wire [7:0] address,
     output wire [31:0] data
 );
 
@@ -16,7 +16,7 @@ reg [7:0] inst2;
 reg [7:0] inst3;
 reg [7:0] inst4;
 
-reg [31:0] instructionMemory[255:0];
+reg [31:0] instructionMemory[127:0];
 reg [7:0] currentInst = 0;
 reg [2:0] dataInCount = 0;
 reg [7:0] fullsize = 0;
@@ -44,7 +44,7 @@ localparam RECEIVE_DONE = 5;
 reg [2:0] romWriteState = RECEIVE_SIZE;
 
 always @(posedge clk) begin
-    if (address <= 32'd255)
+    if (address <= 8'd127)
         data <= instructionMemory[address];
     else
         data <= 32'b10011;


### PR DESCRIPTION
Reduce total UART instructions to 128 and fix address reg size from 32 bits to 8 bits