### PR TITLE
Feat/stall3.0

### DIFF
--- a/project/cpu.v
+++ b/project/cpu.v
@@ -28,7 +28,7 @@ module cpu(
 
 
     // ### Stall Control ###
-    wire stall = 0;
+    wire stall;
 
     // ### Components ###
 
@@ -226,8 +226,7 @@ module cpu(
 
         ._rs2_value(ex_mem_rs2_value),
         .result(ex_mem_result),
-        .PC(de_ex_PC),
-        .stall_pipeline(stall)
+        .PC(de_ex_PC)
     );
 
     wire [31:0] mem_wb_BranchTarget;

--- a/project/cpu.v
+++ b/project/cpu.v
@@ -126,18 +126,20 @@ module cpu(
 
     // ### Pipeline ###
 
+    assign rst_with_bubble = reset || ex_mem_PCSrc;
+
     fetch Fetch(
         .clk(clock_real),
-        .rst(reset),
+        .rst(rst_with_bubble),
         .stall(stall),
         
-        .in_BranchTarget(wb_if_BranchTarget), // May come from writeback, but ideally from memory stage
+        .in_BranchTarget(wb_if_BranchTarget),
         .rom_data(rom_data),
         .rom_address(rom_address),
 
-        .PCSrc(wb_if_PCSrc), // May come from writeback, but ideally from memory stage
+        .PCSrc(wb_if_PCSrc),
 
-        .pc(if_de_pc), // TODO: goes to memory stage for auipc instruction
+        .pc(if_de_pc),
         .instr(if_de_instr)
     );
 
@@ -145,7 +147,7 @@ module cpu(
 
     decode Decode(
         .clk(clock_real),
-        .rst(reset),
+        .rst(rst_with_bubble),
         .stall(stall),
         
         .next_instruction(if_de_instr),

--- a/project/cpu.v
+++ b/project/cpu.v
@@ -26,6 +26,10 @@ module cpu(
     wire [4:0] rb_write_address, rb_read_address1, rb_read_address2;
     wire [31:0] rb_value1, rb_value2, rb_write_value;
 
+
+    // ### Stall Control ###
+    wire stall = 0;
+
     // ### Components ###
 
     // Memories
@@ -125,6 +129,7 @@ module cpu(
     fetch Fetch(
         .clk(clock_real),
         .rst(reset),
+        .stall(stall),
         
         .in_BranchTarget(wb_if_BranchTarget), // May come from writeback, but ideally from memory stage
         .rom_data(rom_data),
@@ -141,6 +146,7 @@ module cpu(
     decode Decode(
         .clk(clock_real),
         .rst(reset),
+        .stall(stall),
         
         .next_instruction(if_de_instr),
         .PC(if_de_pc),
@@ -172,6 +178,7 @@ module cpu(
     execute Execute(
         .clk(clock_real),
         .rst(reset),
+        .stall(stall),
         
         .rs1_value(rb_value1),//(de_ex_value1),
         .rs2_value(rb_value2),//(de_ex_value2),
@@ -217,7 +224,8 @@ module cpu(
 
         ._rs2_value(ex_mem_rs2_value),
         .result(ex_mem_result),
-        .PC(de_ex_PC)
+        .PC(de_ex_PC),
+        .stall_pipeline(stall)
     );
 
     wire [31:0] mem_wb_BranchTarget;
@@ -260,13 +268,15 @@ module cpu(
         // to RAM signals
         .mem_addr(mem_address),
         .mem_write_data(mem_data_in),
-        .mem_write_enable(mem_write_enable)
+        .mem_write_enable(mem_write_enable),
+        .stall_pipeline(stall)
     );
 
     writeback Writeback(
         // inputs
         .clk(clock_real),
         .rst(reset),
+        .stall(stall),
 
         .mem_done(mem_wb_mem_done),
         .data_mem(mem_wb_data_out),

--- a/project/cpu/decode.v
+++ b/project/cpu/decode.v
@@ -2,6 +2,7 @@
 module decode (
     input clk,                // Clock signal
     input rst,                // Reset signal
+    input stall,
 
     input [31:0] next_instruction,
     input [31:0] PC,
@@ -58,6 +59,7 @@ module decode (
 
     always @(posedge clk or posedge rst)
     begin
+
         if (rst) 
         begin
             _instruction <= 0;
@@ -66,9 +68,11 @@ module decode (
         end
         else
         begin
-            _instruction <= next_instruction;
-            _value1 <= regbank_value1;
-            _value2 <= regbank_value2;
+            if (~stall) begin
+                _instruction <= next_instruction;
+                _value1 <= regbank_value1;
+                _value2 <= regbank_value2;
+            end
         end
     end
 

--- a/project/cpu/execute.v
+++ b/project/cpu/execute.v
@@ -2,6 +2,7 @@
 module execute (
     input clk,                 // Clock signal
     input rst,                 // Reset signal
+    input stall,
     
     input [31:0] rs1_value,
     input [31:0] rs2_value,
@@ -42,6 +43,7 @@ module execute (
     output reg out_PCSrc,            // Determines if the PC will come from the PC+4 or from a Branch calculation
     output reg [31:0] out_BranchTarget,
     output reg [31:0] _rs2_value,
+    output reg stall_pipline,
 
     output [31:0] result
 );
@@ -69,6 +71,7 @@ module execute (
 
     always @(posedge clk or posedge rst)
     begin
+        
         if (rst)
         begin
             _rs1_value  <= 0;
@@ -77,8 +80,7 @@ module execute (
             _AluSrc     <= 0;
             _AluOp      <= 0;
             _AluControl <= 0;
-            _imm        <= 0;
-
+            _imm        <= 0;   
             out_MemWrite   <= 0;
             out_MemRead    <= 0;
             out_RegWrite   <= 0;
@@ -89,36 +91,38 @@ module execute (
         end
         else
         begin
-            if(ex_mem_RegWrite && (ex_mem_RegDest != 0) && (rb_read_address1 == ex_mem_RegDest))
-                _rs1_value  <= in_result;
-            else if(mem_wb_RegWrite && (mem_wb_RegDest != 0) && (rb_read_address1 == mem_wb_RegDest))
-                _rs1_value = mem_wb_AluResult;
-            else
-                _rs1_value <= rs1_value;
-
-
-            if(ex_mem_RegWrite && (ex_mem_RegDest != 0) && (rb_read_address2 == ex_mem_RegDest))
-                _rs2_value  <= in_result;
-            else if(mem_wb_RegWrite && (mem_wb_RegDest != 0) && (rb_read_address2 == mem_wb_RegDest))
-                _rs2_value = mem_wb_AluResult;
-            else
-                _rs2_value <= rs2_value;
-
-            _imm        <= imm;
-            _PC         <= PC;
-            _AluSrc     <= AluSrc;
-            _AluOp      <= AluOp;
-            _AluControl <= AluControl;
-            _BranchType <= in_BranchType;
-            _PCSrc <= in_PCSrc;
-            
-            out_MemWrite   <= in_MemWrite;
-            out_MemRead    <= in_MemRead;
-            out_RegWrite   <= in_RegWrite;
-            out_RegDest    <= in_RegDest;
-            out_MemToReg   <= in_MemToReg;
-            out_RegDataSrc <= in_RegDataSrc;
-            out_BranchTarget <= PC + imm;
+            if (~stall) begin
+                if(ex_mem_RegWrite && (ex_mem_RegDest != 0) && (rb_read_address1 == ex_mem_RegDest))
+                    _rs1_value  <= in_result;
+                else if(mem_wb_RegWrite && (mem_wb_RegDest != 0) && (rb_read_address1 == mem_wb_RegDest))
+                    _rs1_value = mem_wb_AluResult;
+                else
+                    _rs1_value <= rs1_value;
+    
+    
+                if(ex_mem_RegWrite && (ex_mem_RegDest != 0) && (rb_read_address2 == ex_mem_RegDest))
+                    _rs2_value  <= in_result;
+                else if(mem_wb_RegWrite && (mem_wb_RegDest != 0) && (rb_read_address2 == mem_wb_RegDest))
+                    _rs2_value = mem_wb_AluResult;
+                else
+                    _rs2_value <= rs2_value;
+    
+                _imm        <= imm;
+                _PC         <= PC;
+                _AluSrc     <= AluSrc;
+                _AluOp      <= AluOp;
+                _AluControl <= AluControl;
+                _BranchType <= in_BranchType;
+                _PCSrc <= in_PCSrc;
+                
+                out_MemWrite   <= in_MemWrite;
+                out_MemRead    <= in_MemRead;
+                out_RegWrite   <= in_RegWrite;
+                out_RegDest    <= in_RegDest;
+                out_MemToReg   <= in_MemToReg;
+                out_RegDataSrc <= in_RegDataSrc;
+                out_BranchTarget <= PC + imm;
+            end
         end
     end
 

--- a/project/cpu/execute.v
+++ b/project/cpu/execute.v
@@ -43,7 +43,6 @@ module execute (
     output reg out_PCSrc,            // Determines if the PC will come from the PC+4 or from a Branch calculation
     output reg [31:0] out_BranchTarget,
     output reg [31:0] _rs2_value,
-    output reg stall_pipline,
 
     output [31:0] result
 );

--- a/project/cpu/fetch.v
+++ b/project/cpu/fetch.v
@@ -1,6 +1,8 @@
 module fetch (
     input clk,                    // Clock signal
     input rst,                    // Reset signal
+    input stall,
+
     input [31:0] in_BranchTarget, // Branch address to jump to if needed
     input [31:0] rom_data,
 
@@ -14,9 +16,9 @@ module fetch (
     always @(posedge clk or posedge rst) begin
         if (rst)
             pc <= 0;
-        else if (PCSrc)
+        else if (PCSrc && ~stall)
             pc <= in_BranchTarget; // Use non-blocking assignment here
-        else
+        else if (~stall)
             pc <= pc + 4; // Increment PC by 4 to fetch the next sequential instruction (10-bit offset)
     end
 

--- a/project/cpu/memory.v
+++ b/project/cpu/memory.v
@@ -4,7 +4,6 @@
 module memory (
     input clk,                 // Clock signal
     input rst,                 // Reset signal
-    input stall,
 
     input [31:0] addr,         // Address input
     input [31:0] data_in,      // Data input to be written
@@ -69,7 +68,6 @@ module memory (
         end
         else 
         begin
-            if (~stall) begin
                 // Input signals from execute and control
                 _addr <= addr;
                 _data_in <= data_in;
@@ -96,10 +94,9 @@ module memory (
                 if (_store)
                 `endif
                     mem_write_enable <= 1;
-            end
         end
     end
 
-    assign stall_pipeline <= ~mem_write_enable
+    assign stall_pipeline = ~mem_write_enable;
 endmodule
 `endif

--- a/project/cpu/memory.v
+++ b/project/cpu/memory.v
@@ -99,5 +99,7 @@ module memory (
             end
         end
     end
+
+    assign stall_pipeline <= ~mem_write_enable
 endmodule
 `endif

--- a/project/cpu/register_bank.v
+++ b/project/cpu/register_bank.v
@@ -5,6 +5,7 @@
 module register_bank(
   input clk,
   input reset,
+  input stall,
   input write_enable,
   input [4:0] write_address,
   input [31:0] write_value,

--- a/project/cpu/register_bank.v
+++ b/project/cpu/register_bank.v
@@ -5,7 +5,6 @@
 module register_bank(
   input clk,
   input reset,
-  input stall,
   input write_enable,
   input [4:0] write_address,
   input [31:0] write_value,

--- a/project/cpu/writeback.v
+++ b/project/cpu/writeback.v
@@ -4,6 +4,8 @@
 module writeback (
     input clk,                  // Clock signal
     input rst,                  // Reset signal
+    input stall,
+
     input mem_done,             // Memory operation done signal from the memory stage
     input [31:0] data_mem,      // Data read from memory
     input [31:0] result_alu,    // Result of ALU operation
@@ -41,15 +43,17 @@ module writeback (
         end
         else 
         begin
-            _mem_done <= mem_done;
-            _MemToReg <= MemToReg;
-            _result_alu <= result_alu;
+            if (~stall) begin
+                _mem_done <= mem_done;
+                _MemToReg <= MemToReg;
+                _result_alu <= result_alu;
 
-            // Control Signal
-            out_RegDest <= in_RegDest;
-            out_PCSrc <= in_PCSrc;
-            out_BranchTarget <= in_BranchTarget;
-            out_RegWrite <= in_RegWrite;
+                // Control Signal
+                out_RegDest <= in_RegDest;
+                out_PCSrc <= in_PCSrc;
+                out_BranchTarget <= in_BranchTarget;
+                out_RegWrite <= in_RegWrite;
+            end
         end
     end
 


### PR DESCRIPTION
This MR implements:
- stall for every step:
   - now we can stop every module of the pipeline with a stall signal
   - the signal should be activated by the execute step when making a division
   - the signal should be activated by the memory access step when loading or storing data in memory
 
- bubble insertion for branch instructions:
  - the fetch, and decode steps will be reseted when a branch instruction arrives in the execute step