### PR TITLE
fix: memory signal build error

### DIFF
--- a/project/cpu.v
+++ b/project/cpu.v
@@ -57,7 +57,7 @@ module cpu(
         .m_address(ram_address),
         .m_data_in(ram_data_in),
         .m_write_enable(ram_write_enable),
-        .m_data_ready(1),
+        .m_data_ready(1'b1),
         .m_data_out(ram_data_out)
     );
 
@@ -243,7 +243,6 @@ module cpu(
 
         // from RAM signals
         .mem_read_data(mem_data_out),
-        .mem_data_ready(mem_data_ready),
 
         // control inputs
         .MemRead(ex_mem_MemRead), // sinal de load

--- a/project/cpu/alu.v
+++ b/project/cpu/alu.v
@@ -44,6 +44,7 @@ module alu (
 
   always @(*)
   begin
+    borrow = 0;
     case (AluControl)
       BITWISE_AND:   result = a & b;     // Bitwise AND
       BITWISE_OR:    result = a | b;     // Bitwise OR

--- a/project/cpu/memory.v
+++ b/project/cpu/memory.v
@@ -68,32 +68,32 @@ module memory (
         end
         else 
         begin
-                // Input signals from execute and control
-                _addr <= addr;
-                _data_in <= data_in;
-                _load <= MemRead;
-                _store <= MemWrite;
+            // Input signals from execute and control
+            _addr <= addr;
+            _data_in <= data_in;
+            _load <= MemRead;
+            _store <= MemWrite;
 
-                // Control signals to the next step
-                out_MemToReg <= in_MemToReg;
-                out_RegWrite <= in_RegWrite;
-                out_RegDest <= in_RegDest;
-                out_RegDataSrc <= in_RegDataSrc;
-                out_PCSrc <= in_PCSrc;
-                out_BranchTarget <= in_BranchTarget;
-                mem_done <= 1;
+            // Control signals to the next step
+            out_MemToReg <= in_MemToReg;
+            out_RegWrite <= in_RegWrite;
+            out_RegDest <= in_RegDest;
+            out_RegDataSrc <= in_RegDataSrc;
+            out_PCSrc <= in_PCSrc;
+            out_BranchTarget <= in_BranchTarget;
+            mem_done <= 1;
 
-                if (mem_write_enable)
-                    mem_write_enable <= 0;
+            if (mem_write_enable)
+                mem_write_enable <= 0;
 
-                `ifdef TESTBENCH
-                if (MemWrite)
-                `elsif TEST
-                if (MemWrite)
-                `else
-                if (_store)
-                `endif
-                    mem_write_enable <= 1;
+            `ifdef TESTBENCH
+            if (MemWrite)
+            `elsif TEST
+            if (MemWrite)
+            `else
+            if (_store)
+            `endif
+                mem_write_enable <= 1;
         end
     end
 


### PR DESCRIPTION
This PR fixes a build error caused by a signal not present in the memory module.

Also, fixes a latch in alu and formats memory code.